### PR TITLE
Update shutup.cr

### DIFF
--- a/src/commands/shutup.cr
+++ b/src/commands/shutup.cr
@@ -3,7 +3,7 @@ module Cryb
     BOT.on_message_create do |payload|
       next if payload.author.bot || payload.content.starts_with? CONFIG.prefix
       
-      if Random.rand(0..3) == 2
+      if Random.rand(0..32) == 16
         BOT.create_message(payload.channel_id, "<@#{payload.author.id}> Shutup")
       end
     end


### PR DESCRIPTION
- Making the scope so small will result in chaos because there is a larger chance to catch a 2 in 4 range than catch a 16 in 33 range.